### PR TITLE
Update admin_media_collection type to support Sylius Fix : #11390

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
-  </state>
-</component>

--- a/src/Resources/views/SyliusUiBundle/Form/imagesTheme.html.twig
+++ b/src/Resources/views/SyliusUiBundle/Form/imagesTheme.html.twig
@@ -17,7 +17,7 @@
 
             {% if prototypes|default is iterable %}
                 {% for key, subPrototype in prototypes %}
-                    <input type="hidden" data-form-prototype="{{ key }}" value="{{ self.collection_item(subPrototype, allow_delete, button_delete_label, '__name__')|e }}" />
+                    <input type="hidden" data-form-prototype="{{ key }}" value="{{ self.collection_item(subPrototype, allow_delete, button_delete_label, prototype_name)|e }}" />
                 {% endfor %}
             {% endif %}
 

--- a/src/Resources/views/SyliusUiBundle/Form/imagesTheme.html.twig
+++ b/src/Resources/views/SyliusUiBundle/Form/imagesTheme.html.twig
@@ -4,11 +4,13 @@
     {% from '@SyliusResource/Macros/notification.html.twig' import error %}
     {% import _self as self %}
     {% set attr = attr|merge({'class': attr.class|default ~ ' controls collection-widget'}) %}
+    {% set prototype_name =  prototype.vars.name ?: '__name__'%}
 
     {% apply spaceless %}
         <div data-form-type="collection" {{ block('widget_container_attributes') }}
                 {% if prototype is defined and allow_add %}
-                    data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, '__name__')|e }}'
+                    data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, prototype_name)|e }}'
+                    data-prototype-name='{{ prototype_name }}'
                 {%- endif -%}
         >
             {{ error(form.vars.errors) }}


### PR DESCRIPTION
Addition of "data-prototype-name" in the creation of the prototype in order to support the modifications made in the Sylius release [v1.7.4](https://github.com/Sylius/Sylius/releases/tag/v1.7.4) and more specifically the following fix: [#11390](https://github.com/Sylius/Sylius/pull/11390) Bug [#9738](https://github.com/Sylius/Sylius/issues/9738) Fix nested form collections ([@vic-blt](https://github.com/vic-blt)).

This fixes the issue #5.